### PR TITLE
Weapons fix

### DIFF
--- a/lua/sps/categories.lua
+++ b/lua/sps/categories.lua
@@ -160,7 +160,7 @@ PS_Categories = {
 					"shrunkenhead",
 					"spikecollar",
 					"trashhattest", --party hat
-					"turtleplush"
+					"turtleplush",
 					"catears"
 				}
 			},

--- a/lua/weapons/weapon_clopper/shared.lua
+++ b/lua/weapons/weapon_clopper/shared.lua
@@ -2,10 +2,11 @@ SWEP.PrintName = "Atheist"
 
 SWEP.Slot = 2
 
+SWEP.ViewModel = ""
 SWEP.WorldModel = ""
 
 function SWEP:PrimaryAttack()
-	self:ExtEmitSound("littleponyass.ogg", {speech=0.8, pitch=math.random(90,110),crouchpitch=math.random(150,170)})
+	self:ExtEmitSound("littleponyass.ogg", {speech=0.8, pitch=math.random(90,110),crouchpitch=math.random(150,170), shared=true})
 end
 
 function SWEP:SecondaryAttack()

--- a/lua/weapons/weapon_deusvult/shared.lua
+++ b/lua/weapons/weapon_deusvult/shared.lua
@@ -2,10 +2,11 @@ SWEP.PrintName = "DEUS VULT"
 
 SWEP.Slot = 2
 
+SWEP.ViewModel = ""
 SWEP.WorldModel = ""
 
 function SWEP:PrimaryAttack()
-	self:ExtEmitSound("deusvult.wav", {speech=0.8, pitch=math.random(90,110),crouchpitch=math.random(150,170)})
+	self:ExtEmitSound("deusvult.wav", {speech=0.8, pitch=math.random(90,110),crouchpitch=math.random(150,170), shared=true})
 end
 
 function SWEP:SecondaryAttack()

--- a/lua/weapons/weapon_squee/shared.lua
+++ b/lua/weapons/weapon_squee/shared.lua
@@ -2,19 +2,8 @@ SWEP.PrintName = "Squee"
 
 SWEP.Slot = 2
 
+SWEP.ViewModel = ""
 SWEP.WorldModel = ""
-
-SWEP.Primary.ClipSize			= -1
-SWEP.Primary.Damage				= -1
-SWEP.Primary.DefaultClip		= -1
-SWEP.Primary.Automatic			= false
-SWEP.Primary.Ammo				= "none"
-
-SWEP.Secondary.ClipSize			= -1
-SWEP.Secondary.DefaultClip		= -1
-SWEP.Secondary.Damage			= -1
-SWEP.Secondary.Automatic		= false
-SWEP.Secondary.Ammo				= "none"
 
 function SWEP:PrimaryAttack()
 	self:ExtEmitSound("squee.wav", {shared=true})


### PR DESCRIPTION
added shared args to deusvult and atheist
removed SWEP.Primary and SWEP.Secondary args from squee since theyre not needed

most importantly, I changed the viewmodel args to null on pony, deusvult and atheist because when switching to a weapon with a viewmodel to a weapon without a viewmodel, you can see split second animation of a pistol being pulled out. this heavily ruins my immersive pony RP experience.