### PR TITLE
Remove !tp as an alias for !thirdperson

### DIFF
--- a/lua/chatcommands/cinema_simple.lua
+++ b/lua/chatcommands/cinema_simple.lua
@@ -2,7 +2,7 @@
 RegisterChatLUACommand({'help','motd'},'ShowMotd("http://steamcommunity.com/groups/swampservers/discussions/0/133255810024702956/")')
 
 RegisterChatConsoleCommand({'skip','voteskip'},"cinema_voteskip")
-RegisterChatLUACommand({'thirdperson','tp'},"THIRDPERSON = !THIRDPERSON")
+RegisterChatLUACommand('thirdperson',"THIRDPERSON = !THIRDPERSON")
 RegisterChatLUACommand('virtualreality',"BOBBINGVIEW = !BOBBINGVIEW")
 RegisterChatLUACommand({'global','globalchat','ooc'},[[chat.AddText("[orange]Press "..input.LookupBinding("messagemode2"):upper().." to speak in Global chat.")]])
 


### PR DESCRIPTION
A while ago I added !tp as an alias/alternative command for !thirdperson, but I forgot that !tp was already being used for teleport, so I undid it. It never actually broke the teleportation command as far as I know but I'm reverting it anyway