### PR TITLE
Fix Billy Herrington SWEP (again)

### DIFF
--- a/lua/sps/items/uniquemodels.lua
+++ b/lua/sps/items/uniquemodels.lua
@@ -27,8 +27,10 @@ PS_UniqueModelProduct({
 	description = "Rest in peace Billy Herrington, you will be missed.",
 	model = 'models/vinrax/player/billy_herrington.mdl',
 	OnBuy = function(self, ply)
-		ply:Give("weapon_billyh")
-		ply:SelectWeapon("weapon_billyh")
+		if SERVER then
+			ply:Give("weapon_billyh")
+			ply:SelectWeapon("weapon_billyh")
+		end
 	end
 })
 

--- a/lua/sps/sh_init.lua
+++ b/lua/sps/sh_init.lua
@@ -153,6 +153,7 @@ end
 function PS_UniqueModelProduct(product)
 	product.playermodel = true
 	product.CanBuyStatusOrig = product.CanBuyStatus
+	product.OnBuyOrig = product.OnBuy
 	function product:CanBuyStatus(ply)
 		if ply:SteamID()=="STEAM_0:0:34404615" and self.class=="fox" then return PS_BUYSTATUS_OK end --kevdamdamhun
 
@@ -177,6 +178,10 @@ function PS_UniqueModelProduct(product)
 	function product:OnBuy(ply)
 		ply:SetNWString("uniqmodl",self.name)
 		ply:SetModel(self.model)
+
+		if self.OnBuyOrig then
+			self:OnBuyOrig(ply)
+		end
 	end
 
 	PS_GenericProduct(product)


### PR DESCRIPTION
I updated the pointshop sh_init.lua with something that should allow product.OnBuy to be used on temp playermodels, which should fix the SWEP (and also allow other temp models to use OnBuy, if needed)