### PR TITLE
HLS fix

### DIFF
--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -41,26 +41,13 @@ if CLIENT then
 					Derma_StringRequest("RTMP Stream Title", "Name your livestream:", LocalPlayer():Nick().."'s Stream", function(title) callback({duration=0,title=title}) end, function() callback() end)
 				end
 			end
-				
-			local urll = "http://swampservers.net/cinema/hls.html";
 
-			vpanel:OpenURL( urll..key )
+			vpanel:OpenURL( "http://swampservers.net/cinema/hls.html?url="..string.JavascriptSafe(key) )
 		end,
 		function()
 			chat.AddText("You need codecs to request this. Press F2.")
 			return callback()
 		end)
-	end
-	
-	function SERVICE:LoadVideo( Video, panel )
-		local urll = "http://swampservers.net/cinema/hls.html"
-		panel:EnsureURL(urll)
- 
-		local k = Video:Key()
-
-		-- Let the webpage handle loading a video
-		local str = string.format( "th_video('%s');", string.JavascriptSafe(k) )
-		panel:QueueJavascript( str )
 	end
 end
 


### PR DESCRIPTION
updated hls.html webpage https://pastebin.com/ECqqJihE

there was an oversight regarding the fact that the codec check doesn't send 'th_video(id)' to the page

you also need to add metadata support for this service since queueing it immediately throws an error about being unable to process the video