### PR TITLE
video debug

### DIFF
--- a/gamemodes/cinema/gamemode/modules/scoreboard/controls/cl_html.lua
+++ b/gamemodes/cinema/gamemode/modules/scoreboard/controls/cl_html.lua
@@ -222,9 +222,16 @@ end
 PANEL.QueueJavaScript = PANEL.QueueJavascript
 PANEL.Call = PANEL.QueueJavascript
 
+concommand.Add("cinema_video_debug",function(ply)
+	ply.videoDebug = not ply.videoDebug
+	print("video debug set to "..tostring(ply.videoDebug))
+end)
+
 function PANEL:ConsoleMessage( msg, func )
 
 	if ( !isstring( msg ) ) then msg = "*js variable*" end
+	
+	if (LocalPlayer().videoDebug) then print(msg) end
 
 	if msg:StartWith("HREF:") then
 		local url =msg:sub(6)


### PR DESCRIPTION
optional debug triggered by a console command to view all errors and messages coming from a page on a theater screen
for some reason some things don't work properly only when on screen but work fine in the F1 browser, the request browser, and even on theater screens in private servers