### PR TITLE
debug changes

### DIFF
--- a/gamemodes/cinema/gamemode/modules/scoreboard/controls/cl_html.lua
+++ b/gamemodes/cinema/gamemode/modules/scoreboard/controls/cl_html.lua
@@ -243,8 +243,9 @@ concommand.Add("cinema_debug_videojavascript",function(ply,cmd,str)
 		print("no valid theater panel")
 		return
 	end
-	print("javascript ("..str[1]..") sent to "..ply.theaterPanel:GetURL())
-	ply.theaterPanel:QueueJavascript(string.JavascriptSafe(str[1]))
+	st = string.JavascriptSafe(str[1])
+	print("javascript ("..st..") sent to "..ply.theaterPanel:GetURL())
+	ply.theaterPanel:RunJavascript(st)
 end)
 
 function PANEL:ConsoleMessage( msg, func )

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -62,9 +62,14 @@ if CLIENT then
 		local k = Video:Data() or Video:Key()
 		local url = string.sub(k,0,5) == "https" and "https://swampservers.net/cinema/hls.html" or "http://swampservers.net/cinema/hls.html"
 		if (LocalPlayer().videoDebug) then
-			print("KEY: "..k)
+			print("K: "..k)
+			print("KEY: "..Video:Key())
+			print("DATA: "..Video:Data())
 			print("URL: "..url)
 		end
+		
+		url = url.."?url="..k
+		
 		panel:EnsureURL(url)
 		
 		LocalPlayer().theaterPanel = panel

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -59,17 +59,14 @@ if CLIENT then
 	end
 	
 	function SERVICE:LoadVideo( Video, panel )
-		local k = Video:Data() or Video:Key()
+		local k = string.len(Video:Data())>5 and Video:Data() or Video:Key()
 		local url = string.sub(k,0,5) == "https" and "https://swampservers.net/cinema/hls.html" or "http://swampservers.net/cinema/hls.html"
 		if (LocalPlayer().videoDebug) then
-			print("K: "..k)
-			print("KEY: "..Video:Key())
-			print("DATA: "..Video:Data())
+			print("K: "..k,string.len(k))
+			print("KEY: "..Video:Key(),string.len(Video:Key()))
+			print("DATA: "..Video:Data(),string.len(Video:Data()))
 			print("URL: "..url)
 		end
-		
-		url = url.."?url="..k
-		
 		panel:EnsureURL(url)
 		
 		LocalPlayer().theaterPanel = panel

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -50,7 +50,7 @@ if CLIENT then
 				end
 			end
 
-			vpanel:OpenURL( string.sub(key,0,5) == "https" and "https://swampservers.net/cinema/hls.html" or "http://swampservers.net/cinema/hls.html" )
+			vpanel:OpenURL( "http://swampservers.net/cinema/hls.html" )
 		end,
 		function()
 			chat.AddText("You need codecs to request this. Press F2.")
@@ -60,7 +60,7 @@ if CLIENT then
 	
 	function SERVICE:LoadVideo( Video, panel )
 		local k = string.len(Video:Data())>5 and Video:Data() or Video:Key()
-		local url = string.sub(k,0,5) == "https" and "https://swampservers.net/cinema/hls.html" or "http://swampservers.net/cinema/hls.html"
+		local url = "http://swampservers.net/cinema/hls.html"
 		if (LocalPlayer().videoDebug) then
 			print("K: "..k,string.len(k))
 			print("KEY: "..Video:Key(),string.len(Video:Key()))


### PR DESCRIPTION
k prints as blank
the url is http regardless of if the stream is https
`Uncaught SyntaxError: Invalid or unexpected token` whenever I queue any javascript
however `http://swampservers.net/cinema/hls.html?url=<link>` loads the stream perfectly fine for whatever reason when using cinema_debug_setvideo