### PR TITLE
EmitSound to ExtEmitSound + remove unused variable

### DIFF
--- a/lua/weapons/weapon_beans/shared.lua
+++ b/lua/weapons/weapon_beans/shared.lua
@@ -60,7 +60,7 @@ end
 
 function SWEP:PrimaryAttack()
 	if SERVER then
-        self.Owner:EmitSound("beans/eating.wav",60)
+        self.Owner:ExtEmitSound("beans/eating.wav", {level=60})
 		self.Owner.BiteStart = 0
 		self.Owner.BitesRem = 3
 		net.Start("Beans_Eat_Start")
@@ -75,7 +75,6 @@ function SWEP:PrimaryAttack()
 end
 
 function SWEP:SecondaryAttack()
-	local pitch = 100 + (self.SoundPitchMod or 0) + (self.Owner:Crouching() and 40 or 0)
 	self:ExtEmitSound("beans/niggaeatingbeans.wav", {speech=1.5, pitch=math.random(90,110),crouchpitch=math.random(150,170)})
 	self.Weapon:SetNextSecondaryFire(CurTime() + 3)
 end


### PR DESCRIPTION
Someone was complaining about how muting the toys in theaters or whatever still allows the bean eating sound to be heard, so I think this should fix it