### PR TITLE
AR2 fix, peacekeeper popup, remove old location code

### DIFF
--- a/lua/autorun/client/hooktimers.lua
+++ b/lua/autorun/client/hooktimers.lua
@@ -247,13 +247,9 @@ end
 LatestReflectionDraw = 0
 
 FullRefractLocation = {
-["Pool"]=true,
-["Jacuzzi"]=true,
 ["Locker Room"]=true,
 ["SportZone"]=true,
 ["Golf"]=true,
-["Upper Caverns"]=true,
-["Lower Caverns"]=true,
 ["The Pit"]=true,
 ["Maintenance Room"]=true,
 ["The Underworld"]=true,
@@ -414,12 +410,6 @@ hook.Add("PrePlayerDraw","PlayerVisControl",function(ply)
 
 	if !ply:InVehicle() then 
 		local transhide = false
-
-		if LocalPlayer():GetLocationName()=="Arcade" then
-			if LocalPlayer():InVehicle() then
-				transhide = true
-			end
-		end
 			
 		if LocalPlayer():InVehicle() and LocalPlayer():GetVehicle():GetNWBool("IsChessSeat", false) then
 			if ChessLocalHideSpectators then transhide = true end

--- a/lua/autorun/misc.lua
+++ b/lua/autorun/misc.lua
@@ -15,7 +15,7 @@ function Safe(ent)
 	if name=="Movie Theater" and (ent:GetPos().y > 1400 or ent:GetPos().z > 150) then
 		return true
 	end
-	if name=="Golf" or name=="Upper Caverns" or name=="Lower Caverns" then
+	if name=="Golf" then
 		if ent:IsPlayer() then
 			local w = ent:GetActiveWeapon()
 			if IsValid(w) and w:GetClass()=="weapon_golfclub" then

--- a/lua/autorun/server/sv_vapeswep.lua
+++ b/lua/autorun/server/sv_vapeswep.lua
@@ -67,7 +67,7 @@ function ReleaseVape(ply)
 	if IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass():sub(1,11) == "weapon_vape" then
 		if ply.vapeCount >= 5 then
 			local loc=Location.GetLocationNameByIndex(Location.Find(ply)):lower()
-			if (ply:InTheater() and not (ply:GetTheater()._AllowItems)) or loc=="trump lobby" or loc=="golf" or loc=="upper caverns" or loc=="lower caverns" or loc=="arcade" then
+			if (ply:InTheater() and not (ply:GetTheater()._AllowItems)) or loc=="trump lobby" or loc=="golf" then
 				ply:PrintMessage( HUD_PRINTTALK, "[red] Take it outside, degenerate filth. ;authority;" )
 			else 
 				net.Start("Vape")

--- a/lua/autorun/theaterprotect.lua
+++ b/lua/autorun/theaterprotect.lua
@@ -70,6 +70,7 @@ if CLIENT then
 		weapon_physgun=true,
 		weapon_slitter=true,
 		weapon_gauntlet=true,
+		weapon_peacekeeper=true
 	}
 
 	hook.Add("HUDPaint", "drawSAFENOTIFY", function()

--- a/lua/entities/ent_secret_weapon.lua
+++ b/lua/entities/ent_secret_weapon.lua
@@ -14,7 +14,8 @@ function ENT:Initialize()
 
     self:DrawShadow(false)
 
-    self:SetAngles(self:GetAngles() + Angle(0, -90, 0))
+    self:SetAngles(Angle(0, -90, 10))
+    self:SetPos(Vector(-2853.360, -316, -284.534) + Vector(-1, 10, -3)) --original position + offset
 
     local phys = self:GetPhysicsObject()
     if IsValid(phys) then

--- a/lua/entities/ent_secret_weapon.lua
+++ b/lua/entities/ent_secret_weapon.lua
@@ -14,7 +14,7 @@ function ENT:Initialize()
 
     self:DrawShadow(false)
 
-    self:SetAngles(self:GetAngles() + Angle(0, 0, -90))
+    self:SetAngles(self:GetAngles() + Angle(0, -90, 0))
 
     local phys = self:GetPhysicsObject()
     if IsValid(phys) then

--- a/lua/entities/prop_trash_field.lua
+++ b/lua/entities/prop_trash_field.lua
@@ -58,7 +58,7 @@ function ENT:ProtectionRadius()
 	local field_size = TrashFieldModelToRadius[self:GetModel()]
 	local locid = self:GetLocation()
 	local ln = Location.GetLocationNameByIndex(locid)
-	if ln=="The Pit" or ln=="Crawl Space" then
+	if ln=="The Pit" then
 		field_size=field_size/2
 	end
 	return field_size

--- a/lua/weapons/weapon_garand.lua
+++ b/lua/weapons/weapon_garand.lua
@@ -252,7 +252,7 @@ end
 
 hook.Add("ScalePlayerDamage", "garandthing", function(ply, hg, dmg)
 	if dmg:GetAmmoType() == game.GetAmmoID("garand") then
-		if ply:GetLocationName() ~= "The Pit" and ply:GetLocationName() ~= "Crawl Space" then
+		if ply:GetLocationName() ~= "The Pit" then
 			dmg:SetDamage(10)
 		end
 	end


### PR DESCRIPTION
Fixed the AR2 angles & position

The 'you are in a safe space' popup will now show if you're holding the peacekeeper

Removed code for locations that aren't in the map e.g. crawl space and upper/lower caverns