### PR TITLE
File Duration Fix

### DIFF
--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_file.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_file.lua
@@ -47,8 +47,7 @@ if CLIENT then
 					if duration==0 then
 						duration=1
 					end
-					--what jwplayer says a livestream is
-					if duration==-1 then
+					if duration<0 then
 						duration=0
 					end
 					print("Duration: "..duration)


### PR DESCRIPTION
flags files with negative durations as livestreams so that it doesn't cause errors