### PR TITLE
HLS Rework

### DIFF
--- a/gamemodes/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/cl_init.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/cl_init.lua
@@ -144,7 +144,7 @@ end
 function ENT:DrawThumbnail()
 
 	-- Thumbnail isn't set yet
-	if self:GetThumbnail() == "" or (self:GetService() == "file" and not GetConVar("swamp_mature_content"):GetBool()) then
+	if self:GetThumbnail() == "" or (theater.Services[self:GetService()] and theater.Services[self:GetService()].Mature) then
 
 		if self:GetService() == "" then
 		

--- a/gamemodes/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/cl_init.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/ents/entities/theater_thumbnail/cl_init.lua
@@ -144,7 +144,7 @@ end
 function ENT:DrawThumbnail()
 
 	-- Thumbnail isn't set yet
-	if self:GetThumbnail() == "" then
+	if self:GetThumbnail() == "" or (self:GetService() == "file" and not GetConVar("swamp_mature_content"):GetBool()) then
 
 		if self:GetService() == "" then
 		

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_dlive.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_dlive.lua
@@ -15,92 +15,16 @@ function SERVICE:GetKey(url)
 end
 
 if CLIENT then
-	function SERVICE:GetVideoInfoClientside(key, callback)
-		EmbeddedCheckCodecs(function()
-			vpanel = vgui.Create("DHTML")
-
-			vpanel:SetSize(1000,100) --dlive hides title if screen is too small
-
-			vpanel:SetAlpha(0)
-
-			vpanel:SetMouseInputEnabled(false)
-			
-			timer.Simple(20,function() 
-				if IsValid(vpanel) then
-					vpanel:Remove() 
-					print("Failed")
-					callback()
-				end
-			end)
-			
-			timer.Create("dliveupdate"..tostring(math.random(1,100000)),1,45,function()
-				if IsValid(vpanel) then
-					vpanel:RunJavascript("console.log('TITLE:'+document.getElementsByClassName('dlive-name text-16-medium text-white')[0].innerText.trim()+': '+document.getElementsByClassName('text-14-medium text-white overflow-hidden')[0].innerText);")
-					vpanel:RunJavascript("document.getElementsByClassName('dplayer-video dplayer-video-current')[0].volume=0;")
-				end
-			end)
-			
-			function vpanel:ConsoleMessage(msg)
-				if (LocalPlayer().videoDebug) then print(msg) end
-				if string.StartWith(msg,"TITLE:") then
-					print("Success!")
-					callback({title=msg:sub(7,-1),duration=0})
-					self:Remove()
-				end
+	function SERVICE:LoadVideo( Video, panel )
+		local url = "http://swampservers.net/cinema/hls.html"
+		panel:EnsureURL(url)
+		
+		timer.Simple(2,function() --using a 2 second delay is the fastest way to load the video, sending th_video any quicker is much much slower for whatever reason
+			if IsValid(panel) then
+				local str = string.format( "th_video('%s',false);", string.JavascriptSafe(Video:Data()) )
+				panel:QueueJavascript( str )
 			end
-
-			vpanel:OpenURL(key)
-		end,
-		function()
-			chat.AddText("You need codecs to request this. Press F2.")
-			return callback()
 		end)
-	end
-	
-	function SERVICE:LoadVideo(Video, panel)
-		panel:EnsureURL(Video:Key())
-		
-		function panel:OnDocumentReady()
-			panel:RunJavascript([[
-				if(typeof VOLUME=="undefined")VOLUME=]]..theater.GetVolume()..[[;
-				barhidden = false;
-			
-				setInterval(function(){
-					if(document.getElementsByClassName('dplayer-video dplayer-video-current').length)document.getElementsByClassName('dplayer-video dplayer-video-current')[0].volume=VOLUME*0.01;
-					
-					var bar = document.getElementsByClassName('dplayer dplayer-no-danmaku dplayer-live dplayer-playing');
-					if(bar.length && !bar[0].classList.contains('dplayer-hide-controller') && !barhidden)bar[0].classList.add('dplayer-hide-controller');barhidden=true;
-					
-					if(document.getElementsByClassName('chatroom-right').length)document.getElementsByClassName('chatroom-right')[0].style.display='none';
-					if(document.getElementsByClassName('application--wrap').length)document.getElementsByClassName('application--wrap')[0].children[0].style.display='none';
-					if(document.getElementsByClassName('channel-header flex-justify-between flex-align-center bg-grey-darken-5 paddinglr-4').length)document.getElementsByClassName('channel-header flex-justify-between flex-align-center bg-grey-darken-5 paddinglr-4')[0].style.display='none';
-					if(document.getElementsByClassName('height-100 position-relative sidebar').length)document.getElementsByClassName('height-100 position-relative sidebar')[0].style.display='none';
-					if(document.getElementsByClassName('livestream-info').length)document.getElementsByClassName('livestream-info')[0].style.display='none';
-					
-					dliveparent=document.getElementsByClassName('height-100 flex-auto overflow-y-auto flex-all-center bg-grey-darken-6')[0].children[0].children;
-					if(dliveparent.length==2){
-						dliveparent[1].style.display='none';
-						dliveparent[0].children[1].classList='';
-					}
-					
-					if(dliveparent.length==1){
-						dliveparent2=document.getElementsByClassName('bg-grey-darken-5 mobile-page')[0].children;
-						dliveparent2[1].style.display='none';
-						dliveparent2[2].style.display='none';
-						dliveparent[0].children[0].classList='';
-					}
-				},200);
-			]])
-		end
-		
-		function panel:ConsoleMessage(msg)
-			if (LocalPlayer().videoDebug and not msg:StartWith("HREF:")) then print(msg) end
-		end
-	end
-	
-	function SERVICE:SetVolume(vol, panel)
-		local str = string.format("VOLUME=%s;", vol)
-		panel:RunJavascript(str) --QueueJavascript is unreliable
 	end
 end
 

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -29,6 +29,8 @@ if CLIENT then
 
 			vpanel:SetMouseInputEnabled(false)
 			
+			local streamwatch_key = string.match(key,"streamwat.ch/(%w+)/*$")
+			
 			timer.Simple(20,function() 
 				if IsValid(vpanel) then
 					vpanel:Remove() 
@@ -39,6 +41,11 @@ if CLIENT then
 
 			function vpanel:ConsoleMessage(msg)
 				if (LocalPlayer().videoDebug) then print(msg) end
+				if msg:StartWith("STREAMWATCHURL:") then
+					vpanel:OpenURL( "http://swampservers.net/cinema/hls.html" )
+					local str = string.format( "th_video('%s');", string.JavascriptSafe(string.sub(msg,16)) )
+					timer.Simple(1,function() vpanel:QueueJavascript( str ) end) --delayed so page can load
+				end
 				if msg:StartWith("LIVE") then
 					self:Remove()
 					print("Success!")
@@ -46,8 +53,8 @@ if CLIENT then
 				end
 			end
 
-			vpanel:OpenURL( "http://swampservers.net/cinema/hls.html" )
-			local str = string.format( "th_video('%s');", string.JavascriptSafe(key) )
+			vpanel:OpenURL( (streamwatch_key and key) or "http://swampservers.net/cinema/hls.html" )
+			local str = string.format( (streamwatch_key and "console.log('STREAMWATCHURL:'+document.title);") or "th_video('%s');", string.JavascriptSafe(key) )
 			vpanel:QueueJavascript( str )
 		end,
 		function()

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -20,57 +20,62 @@ end
 
 if CLIENT then
 	function SERVICE:GetVideoInfoClientside(key, callback)
-		EmbeddedCheckCodecs(function()
-			vpanel = vgui.Create("DHTML")
-
-			vpanel:SetSize(100,100)
-
-			vpanel:SetAlpha(0)
-
-			vpanel:SetMouseInputEnabled(false)
-			
-			local streamwatch_key = string.match(key,"streamwat.ch/(%w+)/*$")
-			
-			timer.Simple(20,function() 
-				if IsValid(vpanel) then
-					vpanel:Remove() 
-					print("Failed")
-					callback()
+		if (key == "TITLE") then
+			Derma_StringRequest("HLS Stream Title", "Name your livestream:", LocalPlayer():Nick().."'s Stream", function(title) callback({title=title}) end, function() callback() end)
+		else
+			EmbeddedCheckCodecs(function()
+				vpanel = vgui.Create("DHTML")
+	
+				vpanel:SetSize(100,100)
+	
+				vpanel:SetAlpha(0)
+	
+				vpanel:SetMouseInputEnabled(false)
+				
+				timer.Simple(20,function() 
+					if IsValid(vpanel) then
+						vpanel:Remove() 
+						print("Failed")
+						callback()
+					end
+				end)
+	
+				function vpanel:ConsoleMessage(msg)
+					if (LocalPlayer().videoDebug) then print(msg) end
+					if msg:StartWith("STREAMWATCHURL:") then
+						vpanel:OpenURL( "http://swampservers.net/cinema/hls.html" )
+						local str = string.format( "th_video('%s');", string.JavascriptSafe(string.sub(msg,16)) )
+						timer.Simple(1,function() vpanel:QueueJavascript( str ) end) --delayed so page can load
+					end
+					if msg:StartWith("LIVE") then
+						self:Remove()
+						print("Success!")
+						Derma_StringRequest("HLS Stream Title", "Name your livestream:", LocalPlayer():Nick().."'s Stream", function(title) callback({title=title}) end, function() callback() end)
+					end
 				end
+	
+				vpanel:OpenURL( key )
+				local str = string.format( "console.log('STREAMWATCHURL:'+document.title);", string.JavascriptSafe(key) )
+				vpanel:QueueJavascript( str )
+			end,
+			function()
+				chat.AddText("You need codecs to request this. Press F2.")
+				return callback()
 			end)
-
-			function vpanel:ConsoleMessage(msg)
-				if (LocalPlayer().videoDebug) then print(msg) end
-				if msg:StartWith("STREAMWATCHURL:") then
-					vpanel:OpenURL( "http://swampservers.net/cinema/hls.html" )
-					local str = string.format( "th_video('%s');", string.JavascriptSafe(string.sub(msg,16)) )
-					timer.Simple(1,function() vpanel:QueueJavascript( str ) end) --delayed so page can load
-				end
-				if msg:StartWith("LIVE") then
-					self:Remove()
-					print("Success!")
-					Derma_StringRequest("RTMP Stream Title", "Name your livestream:", LocalPlayer():Nick().."'s Stream", function(title) callback({duration=0,title=title}) end, function() callback() end)
-				end
-			end
-
-			vpanel:OpenURL( (streamwatch_key and key) or "http://swampservers.net/cinema/hls.html" )
-			local str = string.format( (streamwatch_key and "console.log('STREAMWATCHURL:'+document.title);") or "th_video('%s');", string.JavascriptSafe(key) )
-			vpanel:QueueJavascript( str )
-		end,
-		function()
-			chat.AddText("You need codecs to request this. Press F2.")
-			return callback()
-		end)
+		end
 	end
 	
 	function SERVICE:LoadVideo( Video, panel )
-		local k = string.len(Video:Data())>1 and Video:Data() or Video:Key()
+		local k = Video:Key()
+		if (string.len(Video:Data())>1 and Video:Data() != "true") then
+			k = Video:Data()
+		end
 		local url = "http://swampservers.net/cinema/hls.html"
 		panel:EnsureURL(url)
 		
 		timer.Simple(2,function() --using a 2 second delay is the fastest way to load the video, sending th_video any quicker is much much slower for whatever reason
 			if IsValid(panel) then
-				local str = string.format( "th_video('%s');", string.JavascriptSafe(k) )
+				local str = string.format( "th_video('%s',%s);", string.JavascriptSafe(k), (Video:Data() == "true") )
 				panel:QueueJavascript( str )
 			end
 		end)

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_dlive.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_dlive.lua
@@ -4,5 +4,25 @@
 sv_GetVideoInfo = sv_GetVideoInfo or {}
 
 sv_GetVideoInfo.dlive = function(self, key, ply, onSuccess, onFailure)
-	theater.GetVideoInfoClientside(self:GetClass(), key, ply, onSuccess, onFailure)
+	
+	local onFetchReceive = function( body, length, headers, code )
+		
+		local info = {}
+		info.title = string.match(body,'displayname":"(.+)","p') or "(Unknown)"
+		http.Fetch("https://live.prd.dlive.tv/hls/live/"..(string.match(body,'username":"(.+)","f') or "")..".m3u8",function(body2,length2,headers2,code2) --returns list of active streams
+			if (code2 == 200) then
+				for k,v in ipairs(string.Split(body2,"\n")) do
+					if (v:EndsWith("src/live.m3u8")) then
+						info.data = "https://cors.oak.re/"..v
+						info.duration = 0
+						onReceive(info)
+					end
+				end
+			end
+			onFailure( 'Theater_RequestFailed' )
+		end, onFailure)
+		
+	end
+	
+	self:Fetch( key, onFetchReceive, onFailure )
 end

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_file.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_file.lua
@@ -40,7 +40,7 @@ sv_GetVideoInfo.file = function(self, key, ply, onSuccess, onFailure)
 		if t != nil then
 			t = util.JSONToTable(t).props.file or {}
 			info.title = t.filename or "(Unknown)"
-			info.thumb = t.preview.content.poster_url_tmpl or ""
+			info.thumb = (t.preview.content.poster_url_tmpl and t.preview.content.poster_url_tmpl.."?size=1280x960&size_mode=2") or ""
 			http.Fetch(t.preview.content.metadata_url or "",function(body2) 
 				if (type(util.JSONToTable(body2)) == "table") then
 					info.duration = math.ceil(tonumber(util.JSONToTable(body2).duration))

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
@@ -8,23 +8,51 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 	local streamwatch_key = string.match(key,"streamwat.ch/(%w+)/*$")
 	
 	local onReceive = function(info)
-	
+		
 		http.Post( "https://swampservers.net/fedorabot/gis.php", {q=info.title}, 
 			function(body) 
 				info.thumb="http://swampservers.net/cinema/contain.php?i="..body
 				onSuccess(info)
 			end, onFailure)
-			
+		
 	end
 	
 	local onFetchReceive = function( body, length, headers, code )
 		
+		local info = {}
+		local duration = 0
+		local timed = false
+		for k,v in ipairs(string.Split(body,"\n")) do
+			if (v:StartWith("#EXTINF:")) then
+				duration = duration+tonumber(string.Split(string.sub(v,9),",")[1]) --split because it can be 1.0000,live instead of just 10000,
+			end
+			if (v == "#EXT-X-ENDLIST") then
+				timed = true
+			end
+		end
+		if (string.Split(body,"\n")[1] == "#EXTM3U") then
+			theater.GetVideoInfoClientside(self:GetClass(), "TITLE", ply, function(info) --use player to get the title
+				info.duration = 0
+				if timed then
+					info.duration = math.ceil(duration)
+					info.data = "true"
+				end
+				onReceive(info)
+			end, onFailure)
+		end
+		onFailure( 'Theater_RequestFailed' )
+		
+	end
+	
+	local onFetchReceiveStreamWatch = function( body, length, headers, code )
+		
 		local streamwatch_url = string.match(body,"(http.+%.m3u8)")
 		
 		if streamwatch_url != nil or code == 0 then
-			theater.GetVideoInfoClientside(self:GetClass(), (code==0 and key) or streamwatch_url, ply, function(info)
+			theater.GetVideoInfoClientside(self:GetClass(), (code==0 and key) or streamwatch_url, ply, function(info) --use player to get the hls link due to serverside http issue
 				info.data = streamwatch_url
-				onSuccess(info)
+				info.duration = 0
+				onReceive(info)
 			end, onFailure)
 		else
 			onFailure( 'Theater_RequestFailed' )
@@ -33,8 +61,8 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 	end
 	
 	if streamwatch_key != nil then
-		self:Fetch( "https://streamwat.ch/"..streamwatch_key.."/player.min.js", onFetchReceive, onFailure )
+		self:Fetch( "https://streamwat.ch/"..streamwatch_key.."/player.min.js", onFetchReceiveStreamWatch, onFailure )
 	else
-		theater.GetVideoInfoClientside(self:GetClass(), key, ply, onReceive, onFailure)
+		self:Fetch( key, onFetchReceive, onFailure )
 	end
 end

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
@@ -21,12 +21,11 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 		
 		local streamwatch_url = string.match(body,"(http.+%.m3u8)")
 		
-		if streamwatch_url != nil then
-			theater.GetVideoInfoClientside(self:GetClass(), streamwatch_url, ply, function(info)
+		if streamwatch_url != nil or code == 0 then
+			theater.GetVideoInfoClientside(self:GetClass(), (code==0 and key) or streamwatch_url, ply, function(info)
 				info.data = streamwatch_url
 				onSuccess(info)
 			end, onFailure)
-			
 		else
 			onFailure( 'Theater_RequestFailed' )
 		end
@@ -34,7 +33,7 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 	end
 	
 	if streamwatch_key != nil then
-		self:Fetch( "http://streamwat.ch/"..streamwatch_key.."/player.min.js", onFetchReceive, onFailure )
+		self:Fetch( "https://streamwat.ch/"..streamwatch_key.."/player.min.js", onFetchReceive, onFailure )
 	else
 		theater.GetVideoInfoClientside(self:GetClass(), key, ply, onReceive, onFailure)
 	end

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
@@ -39,8 +39,9 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 				end
 				onReceive(info)
 			end, onFailure)
+		else
+			onFailure( 'Theater_RequestFailed' )
 		end
-		onFailure( 'Theater_RequestFailed' )
 		
 	end
 	

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_native.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_native.lua
@@ -4,5 +4,35 @@
 sv_GetVideoInfo = sv_GetVideoInfo or {}
 
 sv_GetVideoInfo.native = function(self, key, ply, onSuccess, onFailure)
+
+    local onReceive = function(info)
+
+        if info.duration>0 or info.title=="" then
+			local ext = string.Explode(".",key)
+			ext = ext[#ext]
+            local sp = key:reverse():find("/",1,true)
+            info.title = string.Trim(key:lower():reverse():sub(1,sp-1):reverse():gsub(ext..":",""), " ")
+            local sp2 = info.title:lower():find("."..ext,1,true)
+            if sp2 then info.title=info.title:sub(1,sp2-1) end
+            info.title = info.title:gsub("%.smil","")
+            info.title = info.title:gsub("%%20"," ")
+            --info.title = info.title:gsub("%."," ")
+            --info.title = info.title:gsub("%-"," ")
+            info.title = info.title:gsub("_"," ")
+            info.title = info.title:sub(1,1):upper()..info.title:sub(2)
+            for i = 1,info.title:len()-1 do
+                if info.title:sub(i,i)==" " then info.title = info.title:sub(1,i)..info.title:sub(i+1,i+1):upper()..info.title:sub(i+2) end
+            end
+            info.title = string.Trim(info.title, " ")
+        end
+
+        --add a bit for buffering
+        if info.duration>0 then
+            info.duration = info.duration+2
+        end
+
+        onSuccess(info)
+    end
+	
 	theater.GetVideoInfoClientside(self:GetClass(), key, ply, onSuccess, onFailure)
 end


### PR DESCRIPTION
I realized that file thumbnails could have explicit material in them however there aren't any built-in ways to get the maturity rating of a video in a theater from outside the theater so it had to be hardcoded like this.