### PR TITLE
Streamwatch Fix

### DIFF
--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -20,7 +20,7 @@ end
 
 if CLIENT then
 	function SERVICE:GetVideoInfoClientside(key, callback)
-		if (key == "TITLE") then
+		if (string.EndsWith(key,".m3u8")) then
 			Derma_StringRequest("HLS Stream Title", "Name your livestream:", LocalPlayer():Nick().."'s Stream", function(title) callback({title=title}) end, function() callback() end)
 		else
 			EmbeddedCheckCodecs(function()

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
@@ -6,6 +6,7 @@ sv_GetVideoInfo = sv_GetVideoInfo or {}
 sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 
 	local streamwatch_key = string.match(key,"streamwat.ch/(%w+)/*$")
+	local streamwatch_link = nil
 	
 	local onReceive = function(info)
 		
@@ -32,13 +33,14 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 		end
 		if (string.TrimRight(string.Split(body,"\n")[1]) == "#EXTM3U") then
 			ply:PrintMessage(HUD_PRINTCONSOLE,"#EXTM3U") --debug
-			theater.GetVideoInfoClientside(self:GetClass(), "TITLE", ply, function(info) --use player to get the title
+			theater.GetVideoInfoClientside(self:GetClass(), streamwatch_link or key, ply, function(info) --use player to get the title
 				info.duration = 0
+				info.data = streamwatch_link or ""
 				if timed then
 					info.duration = math.ceil(duration)
 					info.data = "true"
 				end
-				onReceive(info)
+				onSuccess(info)
 			end, onFailure)
 		else
 			ply:PrintMessage(HUD_PRINTCONSOLE,body) --debug
@@ -58,6 +60,7 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 				onReceive(info)
 			end, onFailure)
 		elseif streamwatch_url != nil then
+			streamwatch_link = streamwatch_url
 			self:Fetch( string.Replace(streamwatch_url,"https://cors.oak.re/",""), onFetchReceive, onFailure )
 		else
 			ply:PrintMessage(HUD_PRINTCONSOLE,body) --debug

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_native.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_native.lua
@@ -20,6 +20,9 @@ sv_GetVideoInfo.native = function(self, key, ply, onSuccess, onFailure)
 		end
 		info.title = string.Trim(info.title," ")
 		
+		if info.duration>2147483647 then
+			onFailure( 'Theater_RequestFailed' )
+		end
 		info.duration = info.duration+2
 	
 		onSuccess(info)


### PR DESCRIPTION
I want to have the option of choosing whether a video or service has to have the title fetched instead of grabbed from the logs like every request that has a duration of 0. HLS vods have to have their titles manually entered but their duration isn't 0 so the person who queues that link gets to choose its name for the future.