### PR TITLE
HLS CORS Bypass

### DIFF
--- a/gamemodes/cinema/gamemode/modules/scoreboard/cl_request.lua
+++ b/gamemodes/cinema/gamemode/modules/scoreboard/cl_request.lua
@@ -9,7 +9,10 @@ function RequestVideoURL( url )
 
 	LastURLRequested = url
 	
-	RunConsoleCommand( "cinema_video_request", url )
+	--RunConsoleCommand( "cinema_video_request", url )
+	net.Start("VideoRequest")
+		net.WriteString(url)
+	net.SendToServer()
 end
 
 local PANEL = {}

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_file.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_file.lua
@@ -44,7 +44,7 @@ if CLIENT then
 
 			function vpanel:ConsoleMessage(msg)
 				if (LocalPlayer().videoDebug) then print(msg) end
-				if msg:StartWith("DURATION:") then
+				if (msg:StartWith("DURATION:") and msg != "DURATION:NaN") then
 					local duration = math.ceil(tonumber(string.sub(msg,10)))
 					if duration==0 then
 						duration=1
@@ -71,12 +71,14 @@ if CLIENT then
 				end
 			end
 
-			local urll = "http://swampservers.net/cinema/filedata.php?file="
+			local urll = "http://swampservers.net/cinema/file.html"
 			if string.StartWith(key:lower(), "rtmp") then
-				urll = "http://swampservers.net/cinema/filedatavjs.php?file="
+				urll = "http://swampservers.net/cinema/filedatavjs.php?file="..key
 			end
 
-			vpanel:OpenURL( urll..key )
+			vpanel:OpenURL( urll )
+			vpanel:QueueJavascript( string.format( "th_video('%s');", string.JavascriptSafe(key) ) )
+			vpanel:QueueJavascript( "to_volume=0;setInterval(function(){console.log('DURATION:'+player.duration(),100)});" )
 		end,
 		function()
 			chat.AddText("You need codecs to request this. Press F2.")

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -72,7 +72,7 @@ if CLIENT then
 	
 	function SERVICE:LoadVideo( Video, panel )
 		local k = Video:Key()
-		if (not isbool(Video:Data()) and string.len(Video:Data())>1) then
+		if (string.len(Video:Data())>1 and Video:Data() != "true") then
 			k = Video:Data()
 		end
 		local url = "http://swampservers.net/cinema/hls.html"
@@ -80,7 +80,7 @@ if CLIENT then
 		
 		timer.Simple(2,function() --using a 2 second delay is the fastest way to load the video, sending th_video any quicker is much much slower for whatever reason
 			if IsValid(panel) then
-				local str = string.format( "th_video('%s',%s);", string.JavascriptSafe(k), (Video:Data() == true) )
+				local str = string.format( "th_video('%s',%s);", string.JavascriptSafe(k), (Video:Data() == "true") )
 				panel:QueueJavascript( str )
 			end
 		end)

--- a/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sh_hls.lua
@@ -11,6 +11,8 @@ SERVICE.NeedsCodecs = true
 
 SERVICE.LivestreamCacheLife = 0
 
+SERVICE.CacheLife = 0
+
 function SERVICE:GetKey( url )
 	if string.sub( url.path, -5) == ".m3u8" or string.find(url.encoded,"streamwat.ch/(.+)") then
 		return url.encoded
@@ -70,7 +72,7 @@ if CLIENT then
 	
 	function SERVICE:LoadVideo( Video, panel )
 		local k = Video:Key()
-		if (string.len(Video:Data())>1 and Video:Data() != "true") then
+		if (not isbool(Video:Data()) and string.len(Video:Data())>1) then
 			k = Video:Data()
 		end
 		local url = "http://swampservers.net/cinema/hls.html"
@@ -78,7 +80,7 @@ if CLIENT then
 		
 		timer.Simple(2,function() --using a 2 second delay is the fastest way to load the video, sending th_video any quicker is much much slower for whatever reason
 			if IsValid(panel) then
-				local str = string.format( "th_video('%s',%s);", string.JavascriptSafe(k), (Video:Data() == "true") )
+				local str = string.format( "th_video('%s',%s);", string.JavascriptSafe(k), (Video:Data() == true) )
 				panel:QueueJavascript( str )
 			end
 		end)

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
@@ -41,7 +41,7 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 				info.data = datalink or ""
 				if timed then
 					info.duration = math.ceil(duration)
-					info.data = true
+					info.data = "true"
 				end
 				onSuccess(info)
 			end, onFailure)

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_hls.lua
@@ -6,7 +6,7 @@ sv_GetVideoInfo = sv_GetVideoInfo or {}
 sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 
 	local streamwatch_key = string.match(key,"streamwat.ch/(%w+)/*$")
-	local streamwatch_link = nil
+	local datalink = nil
 	
 	local onReceive = function(info)
 		
@@ -20,6 +20,9 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 	
 	local onFetchReceive = function( body, length, headers, code )
 		
+		if (headers["Access-Control-Allow-Origin"] and headers["Access-Control-Allow-Origin"] != "*") then
+			datalink = "https://cors.oak.re/"..(datalink or key)
+		end
 		local info = {}
 		local duration = 0
 		local timed = false
@@ -33,12 +36,12 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 		end
 		if (string.TrimRight(string.Split(body,"\n")[1]) == "#EXTM3U") then
 			ply:PrintMessage(HUD_PRINTCONSOLE,"#EXTM3U") --debug
-			theater.GetVideoInfoClientside(self:GetClass(), streamwatch_link or key, ply, function(info) --use player to get the title
+			theater.GetVideoInfoClientside(self:GetClass(), datalink or key, ply, function(info) --use player to get the title
 				info.duration = 0
-				info.data = streamwatch_link or ""
+				info.data = datalink or ""
 				if timed then
 					info.duration = math.ceil(duration)
-					info.data = "true"
+					info.data = true
 				end
 				onSuccess(info)
 			end, onFailure)
@@ -60,8 +63,8 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 				onReceive(info)
 			end, onFailure)
 		elseif streamwatch_url != nil then
-			streamwatch_link = streamwatch_url
-			self:Fetch( string.Replace(streamwatch_url,"https://cors.oak.re/",""), onFetchReceive, onFailure )
+			datalink = string.Replace(streamwatch_url,"https://cors.oak.re/","")
+			self:Fetch( datalink, onFetchReceive, onFailure )
 		else
 			ply:PrintMessage(HUD_PRINTCONSOLE,body) --debug
 			onFailure( 'Theater_RequestFailed' )
@@ -72,9 +75,8 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 	if streamwatch_key != nil then
 		self:Fetch( "http://streamwat.ch/"..streamwatch_key.."/player.min.js", onFetchReceiveStreamWatch, function()
 			theater.GetVideoInfoClientside(self:GetClass(), key, ply, function(info) --use player to get the hls link due to serverside http issue
-				info.data = streamwatch_url
 				info.duration = 0
-				onReceive(info)
+				onSuccess(info)
 			end, onFailure)
 		end)
 	else

--- a/gamemodes/cinema/gamemode/modules/theater/sh_video.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/sh_video.lua
@@ -113,6 +113,15 @@ end
 
 if SERVER then
 
+	util.AddNetworkString("VideoRequest")
+
+	net.Receive("VideoRequest",function(len,ply)
+		local th = IsValid(ply) and ply:GetTheater()
+		if th then
+			th:RequestVideo(ply,net.ReadString())
+		end
+	end)
+
 	function VIDEO:RequestTime()
 		return self._RequestTime
 	end

--- a/lua/autorun/misc.lua
+++ b/lua/autorun/misc.lua
@@ -102,12 +102,13 @@ if SERVER then
 			end
 		end)
 	end)
-else
-	hook.Add("EntityEmitSound","BasedDepartmentPhone",function(s) --can't change material type and has loud damage sounds so just mute it
-		if (IsValid(s.Entity) and s.Entity:GetClass() == "func_physbox" and s.Entity:GetBrushSurfaces()[1]:GetMaterial():GetName() == "swamponions/af/baseddepartment") then
-			return false
+	
+	hook.Add("EntityTakeDamage","BasedDepartmentPhone",function(target,dmg)
+		if (IsValid(target) and target:GetClass() == "func_physbox" and target:GetBrushSurfaces()[1]:GetMaterial():GetName() == "swamponions/af/baseddepartment") then
+			return true
 		end
 	end)
+else
 	net.Receive("bounce", function()
 		local t = net.ReadTable()
 		PrintTable(t)


### PR DESCRIPTION
I could completely remove the clientside system to get the streamwat.ch hls link but I'll leave it in since people use streamwat.ch sort of often so a failsafe would be fine to keep in.