### PR TITLE
Weapon Ammo Refill Fix 

### DIFF
--- a/lua/swampshop/sh_products.lua
+++ b/lua/swampshop/sh_products.lua
@@ -104,9 +104,9 @@ function SS_WeaponAndAmmoProduct(product)
         else
             local wep = ply:GetWeapon(self.class)
             local ammotype = self.ammotype or game.GetAmmoName(wep:GetPrimaryAmmoType())
-            local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or -1
+            local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or 0
 
-            if (ammogive == -1) then
+            if (ammogive <= 0) then
                 ammogive = nil
             end
 
@@ -120,11 +120,11 @@ function SS_WeaponAndAmmoProduct(product)
         if (ply:HasWeapon(self.class)) then
             local wep = ply:GetWeapon(self.class)
             local ammotype = self.ammotype or (game.GetAmmoName(wep:GetPrimaryAmmoType()))
-            local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or -1
-            if (ammogive == -1) then
+            local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or 0
+            if (ammogive <= 0) then
                 ammogive = nil
             end
-            if (ammotype == nil or ammogive == nil) then return "This weapon cannot be refilled" end
+            if (ammotype == nil or ammogive == nil) then return "Cannot Refill Ammo. Please report this as a bug." end
             local limit = self.maxammo or game.GetAmmoMax(game.GetAmmoID(ammotype)) or 0
             if (limit != 0 and ply:GetAmmoCount(ammotype) >= limit) then return "You can't carry any more of this ammo" end
         end

--- a/lua/swampshop/sh_products.lua
+++ b/lua/swampshop/sh_products.lua
@@ -85,7 +85,9 @@ function SS_WeaponProduct(product)
             ply:SelectWeapon(self.class)
         end
     end
-
+    function product:CannotBuy(ply)
+        return !ply:Alive() and "You're dead!"
+    end
     SS_DeathKeepnotice(product)
     SS_Product(product)
 end
@@ -112,12 +114,14 @@ function SS_WeaponAndAmmoProduct(product)
         ply:SelectWeapon(self.class)
     end
     function product:CannotBuy(ply)
+        if !ply:Alive() then return "You're dead!" end
         if (ply:HasWeapon(self.class)) then
             local wep = ply:GetWeapon(self.class)
             local ammotype = self.ammotype or (game.GetAmmoName(wep:GetPrimaryAmmoType()))
             local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or 0
             local fail = assert(ammotype != nil and ammogive > 0,"shop purchase could not refill" .. ply:Nick() .. "'s "..self.class.." with ".. ammogive .." of "..(ammotype or "<nil ammotype>") ,true)
             if(fail)then return "Error!" end 
+            
             --i am not sure if i am using this correctly
             local limit = self.maxammo or game.GetAmmoMax(game.GetAmmoID(ammotype)) or 0
             if (limit != 0 and ply:GetAmmoCount(ammotype) >= limit) then return "You can't carry any more of this ammo" end

--- a/lua/swampshop/sh_products.lua
+++ b/lua/swampshop/sh_products.lua
@@ -78,13 +78,12 @@ function SS_WeaponProduct(product)
     product.SS_WeaponProduct_OnBuy = product.OnBuy or function() end
 
     function product:OnBuy(ply)
-        ply:Give(self.class)
-        ply:SelectWeapon(self.class)
-        self:SS_WeaponProduct_OnBuy(ply)
-    end
-
-    function product:CannotBuy(ply)
-        return ply:HasWeapon(self.Class) and "You're already carrying this."
+        if(!ply:HasWeapon(self.Class) )then
+            ply:Give(self.class)
+            self:SS_WeaponProduct_OnBuy(ply)
+        else
+            ply:SelectWeapon(self.class)
+        end
     end
 
     SS_DeathKeepnotice(product)
@@ -106,11 +105,7 @@ function SS_WeaponAndAmmoProduct(product)
             local ammotype = self.ammotype or game.GetAmmoName(wep:GetPrimaryAmmoType())
             local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or 0
 
-            if (ammogive <= 0) then
-                ammogive = nil
-            end
-
-            if (ammotype and ammogive) then
+            if (ammotype and ammogive > 0) then
                 ply:GiveAmmo(ammogive, ammotype)
             end
         end
@@ -121,10 +116,9 @@ function SS_WeaponAndAmmoProduct(product)
             local wep = ply:GetWeapon(self.class)
             local ammotype = self.ammotype or (game.GetAmmoName(wep:GetPrimaryAmmoType()))
             local ammogive = self.amount or (wep.Primary and wep.Primary.DefaultClip) or wep:GetMaxClip1() or 0
-            if (ammogive <= 0) then
-                ammogive = nil
-            end
-            if (ammotype == nil or ammogive == nil) then return "Cannot Refill Ammo. Please report this as a bug." end
+            local fail = assert(ammotype != nil and ammogive > 0,"shop purchase could not refill" .. ply:Nick() .. "'s "..self.class.." with ".. ammogive .." of "..(ammotype or "<nil ammotype>") ,true)
+            if(fail)then return "Error!" end 
+            --i am not sure if i am using this correctly
             local limit = self.maxammo or game.GetAmmoMax(game.GetAmmoID(ammotype)) or 0
             if (limit != 0 and ply:GetAmmoCount(ammotype) >= limit) then return "You can't carry any more of this ammo" end
         end


### PR DESCRIPTION
WeaponAndAmmoProduct items should refill ammo correctly now. It will use game-standard ammo refill behavior when no data is supplied.

In most cases the ammotype field can remain blank, as it is acquired automatically. amount will attempt to get SWEP.Primary.DefaultClip, or weapon:GetMaxClip1() if not specified. You should probably manually enter the amount to give for HL2 weapons, otherwise you get whatever a single clip can hold (nothing if if it's a clipless weapon like the grenade, rpg, or crossbow)

maxammo can be used to limit how much ammo a player can carry at once. 


Make sure if you're using WeaponAndAmmoProduct, you actually set up ammo properly on your swep.