### PR TITLE
Fixes

### DIFF
--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_soundcloud.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_soundcloud.lua
@@ -21,5 +21,5 @@ sv_GetVideoInfo.soundcloud = function(self, key, ply, onSuccess, onFailure)
         end
     end
 
-    self:Fetch("https://api.soundcloud.com/resolve.json?url=" .. key .. "/tracks&client_id=3775c0743f360c022a2fed672e33909d", onReceive, onFailure)
+    self:Fetch("https://api-widget.soundcloud.com/resolve?url=" .. key .. "&format=json&client_id=LBCcHmRB8XSStWL6wKH2HPACspQlXg2P", onReceive, onFailure)
 end

--- a/gamemodes/cinema/gamemode/modules/theater/services/sv_youtube.lua
+++ b/gamemodes/cinema/gamemode/modules/theater/services/sv_youtube.lua
@@ -16,17 +16,11 @@ local function convertISO8601Time(duration)
         table.insert(a, part)
     end
 
-    if duration:find('M') and not (duration:find('H') or duration:find('S')) then
-        a = {0, a[1], 0}
-    end
-
-    if duration:find('H') and not duration:find('M') then
-        a = {a[1], 0, a[2]}
-    end
-
-    if duration:find('H') and not (duration:find('M') or duration:find('S')) then
-        a = {a[1], 0, 0}
-    end
+	if duration:find('H') or duration:find('M') or duration:find('S') then
+		a[1] = string.match(duration, "(%d+)H") or 0
+		a[2] = string.match(duration, "(%d+)M") or 0
+		a[3] = string.match(duration, "(%d+)S") or 0
+	end
 
     duration = 0
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/ISO_8601#Durations
fixed old bug regarding ISO 8601 formatting where time values of zero aren't represented so PT1H30M0S would be PT1H30M resulting in the converter outputting 1:30 instead of 1:30:00