### PR TITLE
Added multiple titles (#321)

### DIFF
--- a/gamemodes/cinema/gamemode/entities/ent_snowball_nodamage.lua
+++ b/gamemodes/cinema/gamemode/entities/ent_snowball_nodamage.lua
@@ -44,6 +44,7 @@ function ENT:PhysicsCollide(data)
     if data.HitEntity:IsPlayer() then
         data.HitEntity:SetVelocity(Vector(fwd * 100))
         local ply = data.HitEntity
+        if not ply:IsAFK() then self:GetOwner():AddStat("snowballhit") end
 
         if self.Hardness and self.Hardness > 0 then
             self:EmitSound("physics/flesh/flesh_impact_bullet" .. math.random(1, 4) .. ".wav")

--- a/gamemodes/cinema/gamemode/entities/magicbutton.lua
+++ b/gamemodes/cinema/gamemode/entities/magicbutton.lua
@@ -683,7 +683,7 @@ function ENT:Use(activator)
         end)
 
         local message = self:Effect(activator)
-        activator:AddStat("buttonsearch")
+        activator:AddStat("buttonfind")
         assert(message ~= nil)
         message = "[white]" .. activator:Nick() .. "[fbc] pressed a hidden button " .. message
         BotSayGlobal(";clap;[fbc]" .. message)

--- a/gamemodes/cinema/gamemode/entities/magicbutton.lua
+++ b/gamemodes/cinema/gamemode/entities/magicbutton.lua
@@ -683,6 +683,7 @@ function ENT:Use(activator)
         end)
 
         local message = self:Effect(activator)
+        activator:AddStat("buttonsearch")
         assert(message ~= nil)
         message = "[white]" .. activator:Nick() .. "[fbc] pressed a hidden button " .. message
         BotSayGlobal(";clap;[fbc]" .. message)

--- a/gamemodes/cinema/gamemode/misc/sv_monster.lua
+++ b/gamemodes/cinema/gamemode/misc/sv_monster.lua
@@ -64,6 +64,7 @@ function ReleaseMonster(ply)
                     ply:SetWalkSpeed(1, "monster")
                     ply:SetRunSpeed(1, "monster")
                     ply:SetFOV(ply.realFov, 1)
+                    ply:AddStat("drinkenergy")
                 end
             end)
         end

--- a/gamemodes/cinema/gamemode/misc/sv_monster.lua
+++ b/gamemodes/cinema/gamemode/misc/sv_monster.lua
@@ -57,14 +57,21 @@ function ReleaseMonster(ply)
             ply:SetWalkSpeed(1.5, "monster")
             ply:SetRunSpeed(1.5, "monster")
             ply:SetFOV(ply.realFov + 10, 1)
+            
+            local startpos = ply:GetPos()
 
+            timer.Simple(7, function()
+                if IsValid(ply) and ply:GetPos():Distance(startpos) < 5 then
+                    ply:AddStat("boomer")
+                end
+            end)
+            
             timer.Simple(10, function()
                 if IsValid(ply) then
                     ply.cantStartmonster = false
                     ply:SetWalkSpeed(1, "monster")
                     ply:SetRunSpeed(1, "monster")
                     ply:SetFOV(ply.realFov, 1)
-                    ply:AddStat("drinkenergy")
                 end
             end)
         end

--- a/lua/swamp/chat/sv_commands/bounties.lua
+++ b/lua/swamp/chat/sv_commands/bounties.lua
@@ -6,8 +6,14 @@ hook.Add("PlayerDeath", "BountyDeath", function(ply, infl, atk)
 
     if bounty > 0 and ply ~= atk and atk:IsPlayer() then
         SetPlayerBounty(ply, 0)
+       
+        if not (ply.BountyFunders or {})[atk] and bounty >= 100000 then
+            atk:GroupSetStat("bountyhunt", ply)
+        end
+                     
+        ply.BountyFunders = nil
         atk:SS_GivePoints(bounty)
-        atk:SetPartnerStat("bountykill")
+        
         BotSayGlobal("[edgy]" .. atk:Nick() .. " [fbc]has claimed [gold]" .. ply:Nick() .. "'s [fbc]bounty of [rainbow]" .. bounty .. " [fbc]points!")
     end
 end)
@@ -20,7 +26,7 @@ function GetPlayerBounty(ply)
     return ply.bounty
 end
 
-function SetPlayerBounty(ply, bounty)
+function SetPlayerBounty(ply, bounty, payer)
     ply:SetPData("bounty", bounty)
     ply.bounty = bounty
 end
@@ -36,6 +42,8 @@ function AddBounty(ply, targets, amount)
         for k, v in ipairs(targets) do
             if IsValid(v) then
                 SetPlayerBounty(v, GetPlayerBounty(v) + amount)
+                v.BountyFunders = v.BountyFunders or {}
+                v.BountyFunders[ply] = true
             end
         end
 

--- a/lua/swamp/chat/sv_commands/bounties.lua
+++ b/lua/swamp/chat/sv_commands/bounties.lua
@@ -7,6 +7,7 @@ hook.Add("PlayerDeath", "BountyDeath", function(ply, infl, atk)
     if bounty > 0 and ply ~= atk and atk:IsPlayer() then
         SetPlayerBounty(ply, 0)
         atk:SS_GivePoints(bounty)
+        atk:SetPartnerStat("bountykill")
         BotSayGlobal("[edgy]" .. atk:Nick() .. " [fbc]has claimed [gold]" .. ply:Nick() .. "'s [fbc]bounty of [rainbow]" .. bounty .. " [fbc]points!")
     end
 end)

--- a/lua/swamp/misc/sh_titles.lua
+++ b/lua/swamp/misc/sh_titles.lua
@@ -165,6 +165,70 @@ AddTitle("kleinertp", {
     {1, "Test Subject", 10000}
 }, "Be subjected to one of Dr. Isaac Kleiner's teleportation experiments", "s_kleinertp")
 
+AddTitle("buttonsearch", {
+    {1, "Curious", 0},
+    {10, "Sharp Eye", 0},
+    {100, "Seeker", 0},
+    {1000, "Hunter", 0}
+}, "Find and press %s buttons.", "s_magicbutton")
+
+AddTitle("snowballhit", {
+    {100, "Frosty The Snowman"}
+}, "Hit %s active players with a snowball.", "s_snowballhit")
+
+AddTitle("drinkenergy", {
+    {100, "Boomer"},
+    {500, "Quake Was A Good Game"},
+    {1000, "Quake Champion"}
+}, "Drink your boomer juice %s times", "s_drinkenergy")
+
+AddTitle("bountykill", {
+    {10, "Bounty Hunter", 0},
+    {100, "The Cleaner", 0},
+    {1000, "Hitman", 0}
+}, "Collect %s bounties.", "s_bountykill")
+
+AddTitle("", {
+    {50, "Boom Headshot!", 0},
+    {250, "American Sniper", 0}
+}, "Kill %s non-afk players with headshots.", "s_headshotkill")
+
+AddTitle("kleinerkill", {
+    {100, "Kleiner Killer", 5000},
+    {1000, "Anti Kleiner", 10000},
+    {10000, "Exterminator", 25000}
+}, "Kill %s Kleiners.", "s_kleinerkill")
+
+AddTitle("knifekill", {
+    {25, "Edgelord", 0},
+    {100, "Stab Enthusiast", 0},
+    {1000, "American Psycho", 0}
+}, "Kill %s non-afk players with the throatneck slitter.", "s_knifekill")
+
+AddTitle("theaterkill", {
+    {50, "Protector", 0},
+    {250, "Guardian", 0},
+    {1000, "Homeland Security", 0},
+    {10000, "The Law", 0}
+}, "Defend your theater %s amount of times.", "s_theaterkill")
+
+AddTitle("fistkill", {
+    {25, "Fightclub Member", 5000},
+    {100, "Chad", 1000},
+    {500, "Giga Chad", 25000},
+    {1000, "Billy's Disciple", 100000}
+}, "Get %s kills with the fists.", "s_fistkill")
+
+AddTitle("dodgeballkill", {
+    {25, "Jock", 2500},
+    {100, "Bully", 10000}
+}, "Get %s kills with the dodgeball.", "s_dodgeballkill")
+
+AddTitle("snapkill", {
+    {10, "Snap", 0},
+    {50, "Perfectly Balanced", 0}
+}, "Snap and kill %s players with the Thanos Gauntlet.", "s_snapkill")
+
 -- Jihadi, Fundamentalist, Islamist, Insurrectionist, Extremist, Fanatic
 -- Founder of ISIS and Jihad Squad should be a leaderboard
 AddTitle("", {
@@ -218,3 +282,24 @@ AddTitle("", {
 --NOMINIFY
 --TODO: titles where you don't have a description but the title itself hints at what you do? like a secret achievement but not totally secret
 --TODO: if threshold=true, its 1 but you can put better text on the button in that case
+
+if SERVER then
+    local TitleFunctions =
+    {
+        "weapon_gauntlet" = function(atk) atk:AddStat("snapkill") end,
+        "weapon_slitter" = function(atk,vic) if vic:IsPlayer() && not vic:IsAfk() then atk:AddStat("knifekill") end end,
+        "dodgeball" = function(atk,vic) atk:AddStat("dodgeballkill") end,
+        "weapon_fists" = function(atk) atk:AddStat("fistkill") end
+    }
+
+    hook.Add("PlayerDeath", "TitlesPlayerDeath", function(vic,inf,atk)
+        if atk:IsPlayer() then
+            if TitleFuncions[inf:GetClass()] then TitleFunctions[inf:GetClass()](atk,vic) end
+            if vic:IsPlayer() && not vic:IsAfk() && vic:LastHitGroup() == 1 then atk:AddStat("headshotkill") end
+            if vic:GetModel() == "models/player/kleiner.mdl" then atk:AddStat("kleinerkill") end
+            if atk:InTheater() && vic:InTheater() then
+                if atk:GetTheater():GetOwner() == atk && vic:GetTheater():GetOwner() == atk then atk:AddStat("theaterkill") end
+            end
+        end
+    end)
+end

--- a/lua/swamp/misc/sh_titles.lua
+++ b/lua/swamp/misc/sh_titles.lua
@@ -1,4 +1,4 @@
-﻿-- This file is subject to copyright - contact swampservers@gmail.com for more information.
+-- This file is subject to copyright - contact swampservers@gmail.com for more information.
 local Player = FindMetaTable("Player")
 
 --- Get current title string or ""
@@ -9,16 +9,18 @@ end
 --NOMINIFY
 Titles = {}
 TitleRefreshDir = defaultdict(function() return {} end)
+RewardIdTitleDir = defaultdict(function() return {} end)
 
-if SERVER then
-    for k, v in pairs(player.GetAll()) do
-        v.TitleCache = nil
-    end
-end
 
 --TODO: should we combine all title reward_ids into one? or maybe just some simpler ones like the kleinertp one?
-function AddTitle(reward_id, thresholds, description, nwp_vars, progress_fn, pset_verb)
-    local title = {}
+function AddTitle(thresholds, description, nwp_vars, args)
+    args = args or {}
+    
+    local title = {
+        group_view = args.group_view,
+        reward_id = args.reward_id or "title",
+        nwp_vars = isstring(nwp_vars) and {nwp_vars} or nwp_vars
+    }
     table.insert(Titles, title)
 
     if isstring(thresholds) then
@@ -35,11 +37,22 @@ function AddTitle(reward_id, thresholds, description, nwp_vars, progress_fn, pse
 
             if i <= n then
                 local v = thresholds[i]
+                local cutoff = v[1]
 
-                return i, v[1], v[2], (v[3] or 0)
+                if isstring(cutoff) then
+                    cutoff = NWGlobal[cutoff] or 999999999
+                end
+
+                return i, cutoff, v[2], (v[3] or 0)
             end
         end
     end
+
+    local treward = 0
+    for i,min,text,reward in title:Thresholds() do
+        treward = treward + reward
+    end
+    if treward==0 then title.reward_id =nil end
 
     if isstring(description) then
         function title:Description(i, min)
@@ -51,11 +64,6 @@ function AddTitle(reward_id, thresholds, description, nwp_vars, progress_fn, pse
         end
     end
 
-    if isstring(nwp_vars) then
-        nwp_vars = {nwp_vars}
-    end
-
-    title.nwp_vars = nwp_vars
 
     local function num(p)
         if not isnumber(p) then
@@ -65,10 +73,10 @@ function AddTitle(reward_id, thresholds, description, nwp_vars, progress_fn, pse
         return p
     end
 
-    progress_fn = progress_fn or function(ply)
+    local progress_fn = args.progress_fn or function(ply)
         local p = 0
 
-        for i, var in ipairs(nwp_vars) do
+        for i, var in ipairs(title.nwp_vars) do
             p = p + num(ply.NWP[var])
         end
 
@@ -81,199 +89,177 @@ function AddTitle(reward_id, thresholds, description, nwp_vars, progress_fn, pse
     function title:Progress(ply)
         local p = num(progress_fn(ply))
 
-        if SERVER and reward_id ~= "" then
-            local r = 0
-            local t = nil
-            local im = 0
+        -- if SERVER and reward_id ~= "" then
+        --     local r = 0
+        --     local t = nil
+        --     local im = 0
 
-            for i, min, name, reward in self:Thresholds() do
-                if min > p then break end
-                t = name
-                r = r + reward
-                im = i
-            end
+        --     for i, min, name, reward in self:Thresholds() do
+        --         if min > p then break end
+        --         t = name
+        --         r = r + reward
+        --         im = i
+        --     end
 
-            if (ply[maxkey] or 0) < im and not ply.SUPPRESSTITLEUNLOCK then
-                ply:Notify("Unlocked a new title: " .. t .. "")
-            end
+        --     if (ply[maxkey] or 0) < im then
+        --         if ply.TitlesInitialized then
+        --             ply:Notify("Unlocked a new title: " .. t .. "")
+        --         end
 
-            ply[maxkey] = im
-            ply:PointsReward(reward_id, r, "unlocking a title")
-        end
+        --         PlayerTitleRewardRefresh[ply][reward_id] = true
+        --     end
+
+        --     ply[maxkey] = im
+        -- end
 
         return p
     end
 
-    title.pset_verb = pset_verb
+    function title:CurrentReward(ply)
+        local p = num(progress_fn(ply))
+        local r = 0
 
-    for i, v in ipairs(nwp_vars) do
-        table.insert(TitleRefreshDir[v], titleindex)
+        for i, min, name, reward in self:Thresholds() do
+            if min > p then break end
+            r = r + reward
+        end
+
+        return r
+    end
+
+    if title.reward_id then
+        table.insert(RewardIdTitleDir[title.reward_id], title)
+    end
+
+    for i, v in ipairs(title.nwp_vars) do
+        table.insert(TitleRefreshDir[v], title)
     end
 end
 
---AddTitle(reward_id, thresholds, description, nwpvars, progressfn)
---reward_id: string to identify points given for this sequence, use empty string if there are no rewards
+--AddTitle(thresholds, description, nwpvars, args)
 --thresholds: {{progress1, title1, reward1}, {progress2, title2, reward2}} rewards are optional
 --description: string which can be formatted with the threshold for the next target, or list of strings corresponding to each level
 --nwp_vars: var or list of vars that are used to calculate progress, so when they change the server can strip the title if necessary
+--args:
+--reward_id: string to identify points given for this sequence, use empty string if there are no rewards
 --progress_fn: optional function to compute progess, defaults to summing nwp vars
---pset_verb: optional, verb to use if nwpvar1 is a pset and should be trackable
-AddTitle("", "Newfriend", "Welcome to the Swamp", {}, function() return true end)
+--group_view: optional, pset id and verb to track with
+AddTitle("Newfriend", "Welcome to the Swamp", {}, {
+    progress_fn = function() return true end
+})
 
 -- TODO: make income max at 500k due to new ways to get points, make leaderboards network the threshold to get to a certain level
 --jolly
-AddTitle("christmas", {
+AddTitle({
     {1, "Festive", 25000},
-}, "During December, give a present (from shop) to another player", "s_christmas")
+}, "During December, give a present (from shop) to another player", "s_christmas", {
+    reward_id = "christmas"
+})
 
 -- {1000, "Saint Nick", 1000000}
-AddTitle("giftgiver", {
-    {100, "Gift Giver", 1000000}
-}, "Give a present (from shop) to %s different players", "s_giftgiver", function(ply) return PartnerSetSize(ply.NWP.s_giftgiver or "") end, "gifted")
+AddTitle({
+    {100, "Gift Giver", 1000000},
+    {"s_giftgiver_size_place1", "Saint Nick", 0}
+}, "Give a present (from shop) to %s different players", "s_giftgiver_size", {
+    reward_id = "giftgiver",
+    
+    group_view = {"s_giftgiver", "gifted"}
+})
 
-AddTitle("", {
-    {200, "Gift Receiver"},
-    {1000, "Spoiled Child"},
+AddTitle({
+    {200, "Gift Receiver", 10000},
+    {1000, "Greedy", 100000},
+    {10000, "Spoiled Child", 1000000},
 }, "Open %s presents which you didn't buy yourself", "s_giftopener")
 
-AddTitle("popcornhit", {
+AddTitle({
     {10, "Goofball", 2000},
     {200, "Troll", 10000},
     {1000, "Minge", 50000},
     {100000, "Retard", 0}
-}, "Throw popcorn in someone's face %s times", "s_popcornhit")
+}, "Throw popcorn in someone's face %s times", "s_popcornhit", {
+    reward_id = "popcornhit"
+})
 
-AddTitle("mined", {
+AddTitle({
     {20, "Digger", 10000},
     {100, "Spelunker", 20000},
     {500, "Excavator", 30000},
     {2000, "Earth Mover", 40000},
     {10000, "Minecraft Steve", 50000}
-}, "Dig up %s pieces of ore (In Minecraft)", "s_mined")
+}, "Dig up %s pieces of ore (In Minecraft)", "s_mined", {
+    reward_id = "mined"
+})
 
-AddTitle("garfield", {
+AddTitle({
     {200, "Chonkers", 10000},
     {1000, "Fat Cat", 100000},
     {10000, "I Eat, Jon.", 1000000}
-}, "Become Garfield and grow to weigh at least %s pounds", "s_garfield")
+}, "Become Garfield and grow to weigh at least %s pounds", "s_garfield", {
+    reward_id = "garfield"
+})
 
-AddTitle("megavape", {
+AddTitle({
     {1, "Vapist", 50000}
 }, "Find the mega vape and hit it", "s_megavape")
 
-AddTitle("kleinertp", {
+AddTitle({
     {1, "Test Subject", 10000}
 }, "Be subjected to one of Dr. Isaac Kleiner's teleportation experiments", "s_kleinertp")
 
-AddTitle("buttonsearch", {
-    {1, "Curious", 0},
-    {10, "Sharp Eye", 0},
-    {100, "Seeker", 0},
-    {1000, "Hunter", 0}
-}, "Find and press %s buttons.", "s_magicbutton")
-
-AddTitle("snowballhit", {
-    {100, "Frosty The Snowman"}
-}, "Hit %s active players with a snowball.", "s_snowballhit")
-
-AddTitle("drinkenergy", {
-    {100, "Boomer"},
-    {500, "Quake Was A Good Game"},
-    {1000, "Quake Champion"}
-}, "Drink your boomer juice %s times", "s_drinkenergy")
-
-AddTitle("bountykill", {
-    {10, "Bounty Hunter", 0},
-    {100, "The Cleaner", 0},
-    {1000, "Hitman", 0}
-}, "Collect %s bounties.", "s_bountykill")
-
-AddTitle("", {
-    {50, "Boom Headshot!", 0},
-    {250, "American Sniper", 0}
-}, "Kill %s non-afk players with headshots.", "s_headshotkill")
-
-AddTitle("kleinerkill", {
-    {100, "Kleiner Killer", 5000},
-    {1000, "Anti Kleiner", 10000},
-    {10000, "Exterminator", 25000}
-}, "Kill %s Kleiners.", "s_kleinerkill")
-
-AddTitle("knifekill", {
-    {25, "Edgelord", 0},
-    {100, "Stab Enthusiast", 0},
-    {1000, "American Psycho", 0}
-}, "Kill %s non-afk players with the throatneck slitter.", "s_knifekill")
-
-AddTitle("theaterkill", {
-    {50, "Protector", 0},
-    {250, "Guardian", 0},
-    {1000, "Homeland Security", 0},
-    {10000, "The Law", 0}
-}, "Defend your theater %s amount of times.", "s_theaterkill")
-
-AddTitle("fistkill", {
-    {25, "Fightclub Member", 5000},
-    {100, "Chad", 1000},
-    {500, "Giga Chad", 25000},
-    {1000, "Billy's Disciple", 100000}
-}, "Get %s kills with the fists.", "s_fistkill")
-
-AddTitle("dodgeballkill", {
-    {25, "Jock", 2500},
-    {100, "Bully", 10000}
-}, "Get %s kills with the dodgeball.", "s_dodgeballkill")
-
-AddTitle("snapkill", {
-    {10, "Snap", 0},
-    {50, "Perfectly Balanced", 0}
-}, "Snap and kill %s players with the Thanos Gauntlet.", "s_snapkill")
-
 -- Jihadi, Fundamentalist, Islamist, Insurrectionist, Extremist, Fanatic
 -- Founder of ISIS and Jihad Squad should be a leaderboard
-AddTitle("", {
+AddTitle({
     {10, "Insurrectionist"},
     {20, "Terrorist"},
     {30, "Islamist"},
-    {40, "Founder of ISIS"}
+    {"s_bigjihad_place1", "Founder of ISIS"}
 }, "Kill at least %s active players in a suicide bombing", "s_bigjihad")
 
-AddTitle("", {
+AddTitle({
     {50, "Suicide Bomber"},
-    {1000, "Jihad Squad"}
-}, "Kill a total of %s players by jihading theaters", "s_theaterjihad")
+    {"s_theaterjihad_place5", "Jihad Squad"}
+}, {"Kill a total of %s players by jihading theaters", "Be among the top 5 theater jihaders"}, "s_theaterjihad")
 
-AddTitle("", {
+AddTitle({
     {99, "Cloud Chaser"},
     {999, "Junkie"},
     {9999, "Dropout"}
 }, "Hit a vape %s times", "s_vapehit")
 
 -- Philosopher, Intellectual, Elegant, Suave, Stylish
-AddTitle("", {
+AddTitle({
     {1000, "Classy"},
     {10000, "Elegant"},
     {100000, "Sophisticated"},
     {1000000, "Enlightened"}
 }, "Tip your flappy fedora %s times", "s_fedoratip")
 
-AddTitle("", {
-    {1, "Patriot"},
-    {2, "Golden Patriot"},
-    {3, "Platinum Patriot"}
-}, {"Visit Donald Trump's donation box and give at least 100,000 points", "Be on Donald Trump's donation leaderboard", "Be the top donor to Donald Trump"}, {"s_trump_donation", "s_trump_donation_leader"}, function(ply) return ((ply.NWP.s_trump_donation or 0) >= 100000 and 1 or 0) + (ply.NWP.s_trump_donation_leader and 1 or 0) + (ply.NWP.s_trump_donation_leader == 1 and 1 or 0) end)
+AddTitle({
+    {100000, "Patriot"},
+    {"s_trump_donation_place10", "Golden Patriot"},
+    {"s_trump_donation_place1", "Platinum Patriot"}
+}, {"Visit Donald Trump's donation box and give at least 100,000 points", "Be on Donald Trump's donation leaderboard", "Be the top donor to Donald Trump"}, "s_trump_donation")
 
-AddTitle("", {
-    {1, "Ally"},
-    {2, "Libtard"},
-    {3, "Greatest Ally"}
-}, {"Visit Joe Biden's donation box and give at least 100,000 points", "Be on Joe Biden's donation leaderboard", "Be the top donor to Joe Biden"}, {"s_lefty_donation", "s_lefty_donation_leader"}, function(ply) return ((ply.NWP.s_lefty_donation or 0) >= 100000 and 1 or 0) + (ply.NWP.s_lefty_donation_leader and 1 or 0) + (ply.NWP.s_lefty_donation_leader == 1 and 1 or 0) end)
+AddTitle({
+    {100000, "Ally"},
+    {"s_lefty_donation_place10", "Libtard"},
+    {"s_lefty_donation_place1", "Greatest Ally"}
+}, {"Visit Joe Biden's donation box and give at least 100,000 points", "Be on Joe Biden's donation leaderboard", "Be the top donor to Joe Biden"}, "s_lefty_donation")
 
 --todo: print who currently has the title?
-AddTitle("", {
-    {1, "The 1%"},
-    {13, "Illuminati"}
-}, {"Be among the 15 richest players", "Be among the 3 richest players"}, "points_leader", function(ply) return 16 - (ply.NWP.points_leader or 16) end)
+AddTitle({
+    {"points_place15", "The 1%"},
+    {"points_place3", "Illuminati"}
+}, {"Be among the 15 richest players", "Be among the 3 richest players"}, "points")
+
+AddTitle({
+    {20, "Bug Chaser"},
+    {100, "Dev Server Proponent"}
+}, "Experience %s different Lua errors.", "s_clienterror_size")
+
+
+
 -- AddTitle("vandal", {
 --     {200, "Tagger", 10000},
 --     {1000, "Vandal", 100000}
@@ -282,24 +268,3 @@ AddTitle("", {
 --NOMINIFY
 --TODO: titles where you don't have a description but the title itself hints at what you do? like a secret achievement but not totally secret
 --TODO: if threshold=true, its 1 but you can put better text on the button in that case
-
-if SERVER then
-    local TitleFunctions =
-    {
-        "weapon_gauntlet" = function(atk) atk:AddStat("snapkill") end,
-        "weapon_slitter" = function(atk,vic) if vic:IsPlayer() && not vic:IsAfk() then atk:AddStat("knifekill") end end,
-        "dodgeball" = function(atk,vic) atk:AddStat("dodgeballkill") end,
-        "weapon_fists" = function(atk) atk:AddStat("fistkill") end
-    }
-
-    hook.Add("PlayerDeath", "TitlesPlayerDeath", function(vic,inf,atk)
-        if atk:IsPlayer() then
-            if TitleFuncions[inf:GetClass()] then TitleFunctions[inf:GetClass()](atk,vic) end
-            if vic:IsPlayer() && not vic:IsAfk() && vic:LastHitGroup() == 1 then atk:AddStat("headshotkill") end
-            if vic:GetModel() == "models/player/kleiner.mdl" then atk:AddStat("kleinerkill") end
-            if atk:InTheater() && vic:InTheater() then
-                if atk:GetTheater():GetOwner() == atk && vic:GetTheater():GetOwner() == atk then atk:AddStat("theaterkill") end
-            end
-        end
-    end)
-end


### PR DESCRIPTION
* Added three titles.

Added thanos snap titles.
Added bounty collection titles.
Added button finding titles.

* Title update.

Added multiple new titles.
Added new server table TitleFuncs.
Added new server function TitlesPlayerDeath.
Added new server hook TitlesPlayerDeath.
Fixed thanos snap table not correctly being ordered.
Removed unnecessary logic in gauntlet snap.

* Fix typo in bounty kill title.

* Title changes.

Added dodgeball titles "Underdog" and "Strongarm".
Changed snap kill requirements.
Changed kleiner kill rewards.
Changed fist kill rewards.
Changed dodgeball rewards.

* Fix missing zero on fist kills.

* Titles requested by Purapoint.

Added snowball hitting title requested by Purapoint.
Added energy drinking title requested by Purapoint.
Renamed TitleFuncs to TitleFunctions for better clarity.

* Use strings not bracketed strings.

* Put logic in hook.Add, not separate function.

* Requested changed.

Added multiple theater protection titles.
Changed bounty kill stat from AddStat to SetPartnerStat.
Changed fist kill titles to better reflect it's theme.
Changed snap bounty title function and reward function for better consistency.
Changed button search titles to recommended titles.
Changed title function and reward function for kleiner kills to kleinerkill for consistency.
Changed reward function for bounty kill to s_bountykill for consistency.
Move energy drink AddStat from drink to timer.
Removed headshot kill rewards.
Removed third headshot kill title.

* Dev work.

Revert fist kill titles.
Changed dodgeball kill titles.

* Fix bad formatting for table.