### PR TITLE
Prevent prop spawn while dead.

### DIFF
--- a/lua/swamp/swampshop/sh_products.lua
+++ b/lua/swamp/swampshop/sh_products.lua
@@ -7,7 +7,7 @@ function SS_Product(product)
 
     function product:CannotBuy(ply)
         if ply.SQLCreatingItem then return "Database lock, try again." end
-        if self.class == "prop_physics" or weapons.Get(self.class) or weapons:StartsWith("weapon_") then ply:Notify('Cannot buy ', self:GetName(), ' while dead.') return end
+        if self.class == "prop_physics" then ply:Notify('Cannot spawn props while dead.') return end
 
         return product:SS_Product_CannotBuy(ply) or not ply:SS_HasPoints(self.price) and SS_CANNOTBUY_AFFORD
     end

--- a/lua/swamp/swampshop/sh_products.lua
+++ b/lua/swamp/swampshop/sh_products.lua
@@ -7,7 +7,7 @@ function SS_Product(product)
 
     function product:CannotBuy(ply)
         if ply.SQLCreatingItem then return "Database lock, try again." end
-        if self.class == "prop_physics" then ply:Notify('Cannot spawn props while dead.') return end
+        if !ply:Alive() and self.class == "prop_physics" then ply:Notify('Cannot spawn props while dead.') return end
 
         return product:SS_Product_CannotBuy(ply) or not ply:SS_HasPoints(self.price) and SS_CANNOTBUY_AFFORD
     end

--- a/lua/swamp/swampshop/sh_products.lua
+++ b/lua/swamp/swampshop/sh_products.lua
@@ -7,6 +7,7 @@ function SS_Product(product)
 
     function product:CannotBuy(ply)
         if ply.SQLCreatingItem then return "Database lock, try again." end
+        if self.class == "prop_physics" or weapons.Get(self.class) or weapons:StartsWith("weapon_") then ply:Notify('Cannot buy ', self:GetName(), ' while dead.') return end
 
         return product:SS_Product_CannotBuy(ply) or not ply:SS_HasPoints(self.price) and SS_CANNOTBUY_AFFORD
     end


### PR DESCRIPTION
Got tired of others being able to spawn explosive props when dead. I'm not 100% sure if this will actually prevent it, but judging from how products work it seems like it might work.

Tell me otherwise if I can do this better.