### PR TITLE
[feature] Initial support for a YugenAnime Scraper

### DIFF
--- a/lua/cinema/theater/services/sh_yugen.lua
+++ b/lua/cinema/theater/services/sh_yugen.lua
@@ -46,7 +46,7 @@ if CLIENT then
                 callback()
             end
 
-            if YugenData.stream and YugenVideoInfo.duration then
+            if YugenData.stream and YugenVideoInfo.duration and YugenVideoInfo.thumb then
                 YugenVideoInfo.data = util.TableToJSON({
                     url = YugenData.stream
                 })
@@ -56,27 +56,24 @@ if CLIENT then
             end
         end)
 
-        http.Post("https://yugen.to/api/embed", {
+        http.Post("https://yugen.to/api/embed/", {
             id = ani_id,
             ac = 0
         }, function(body, length, headers, code)
+
             local tab = util.JSONToTable(body)
             local hls_link = tab["hls"][0]
             local stream = ""
 
-            -- http playlist parsing, gets the best quality by default
-            http.Fetch(hls_link, function()
-                -- todo: for each newline
-                for _, v in ipairs(string.Split(body, ",")) do
-                    if string.find(v, "RESOLUTION=") then
-                        -- always grab the best resolution from the playlist
-                        local res_split = string.Split(v, "RESOLUTION=")
-                        resolution = res_split[#res_split]
-                    end
+            -- grabs video thumbnail from embed api
+            -- side-note: is webp supported in swamp? i am not sure.
+            YugenVideoInfo.thumb = tab["thumbnail"]
 
-                    if string.find(v, ".m3u8") and string.match(resolution, "%d+x%d+") then
-                        stream = v
-                    end
+            -- http playlist parsing, gets the best quality by default
+            -- todo, for now
+            http.Fetch(hls_link, function()
+                for _, v in ipairs(string.Split(body, "\n")) do
+                    stream = v
                 end
             end, function(message)
                 print("m3u8 playlist error - ", message)

--- a/lua/cinema/theater/services/sh_yugen.lua
+++ b/lua/cinema/theater/services/sh_yugen.lua
@@ -1,0 +1,120 @@
+local SERVICE = {
+    Name = "Yugen",
+    NeedsCodecs = true,
+    CacheFile = 0
+}
+
+function SERVICE:GetKey(url)
+    if string.match(url.encoded, "yugen.to/watch/%d+/%w*/%d+/") then return url.encoded end
+end
+
+if CLIENT then
+    function SERVICE:GetVideoInfoClientside(key, callback)
+        local ani_info = string.Split(key, '/')
+        local ani_id = ""
+
+        if string.match(key, "yugen.to/watch/%d+/%w*-dub/%d+/") then
+            ani_id = util.Base64Encode(ani_info[2] + '|' + ani_info[4] + '|dub')
+        else
+            ani_id = util.Base64Encode(ani_info[2] + '|' + ani_info[4])
+        end
+
+        -- cheesy workaround to getting something close to a video title
+        -- technically you could also grab it directly from MAL as it's what yugen uses,
+        -- but it relies on api keys and whatnot + i'm not with the patience lmao
+        local function getVideoTitle(title_arr)
+            local title = ""
+
+            for _, t in title_arr do
+                title = title + string.upper(string.sub(t, 1, 1)) + string.sub(t, 2)
+            end
+
+            return title + "- Episode " + ani_info[4]
+        end
+
+        YugenVideoInfo = {
+            title = getVideoTitle(string.Split(ani_info[3], '-')),
+        }
+
+        -- gather video stream, and duration. derived from the bflix code
+        local YugenData = {}
+
+        timer.Create("AwaitYugen", 1, 40, function()
+            if timer.RepsLeft("AwaitYugen") == 0 then
+                print("Fail!")
+                timer.remove("AwaitYugen")
+                callback()
+            end
+
+            if YugenData.stream and YugenVideoInfo.duration then
+                YugenVideoInfo.data = util.TableToJSON({
+                    url = YugenData.stream
+                })
+
+                timer.remove("AwaitYugen")
+                callback(YugenVideoInfo)
+            end
+        end)
+
+        http.Post("https://yugen.to/api/embed", {
+            id = ani_id,
+            ac = 0
+        }, function(body, length, headers, code)
+            local tab = util.JSONToTable(body)
+            local hls_link = tab["hls"][0]
+            local stream = ""
+
+            -- http playlist parsing, gets the best quality by default
+            http.Fetch(hls_link, function()
+                -- todo: for each newline
+                for _, v in ipairs(string.Split(body, ",")) do
+                    if string.find(v, "RESOLUTION=") then
+                        -- always grab the best resolution from the playlist
+                        local res_split = string.Split(v, "RESOLUTION=")
+                        resolution = res_split[#res_split]
+                    end
+
+                    if string.find(v, ".m3u8") and string.match(resolution, "%d+x%d+") then
+                        stream = v
+                    end
+                end
+            end, function(message)
+                print("m3u8 playlist error - ", message)
+            end)
+
+            -- duration from stream
+            local duration = 0
+
+            http.Fetch(stream, function(st_body)
+                if #string.Split(st_body, "\n") < 2 then
+                    callback()
+
+                    return
+                end
+
+                for _, v in ipairs(string.Split(st_body, "\n")) do
+                    if v:StartWith("#EXTINF:") then
+                        duration = duration + tonumber(string.Split(string.sub(v, 9), ",")[1])
+                    end
+                end
+
+                YugenVideoInfo.duration = math.ceil(duration)
+                YugenData.stream = stream
+            end, function(message)
+                print("m3u8 stream error - ", message)
+            end)
+        end, function(message)
+            print("embed error - ", message)
+        end, {
+            ["x-requested-with"] = "XMLHttpRequest" -- required
+        })
+    end
+
+    function SERVICE:LoadVideo(Video, panel)
+        panel:EnsureURL("https://swamp.sv/s/cinema/file.html")
+        local key = util.JSONToTable(Video:Data()).url
+        panel:QueueJavascript(string.format("th_video('%s','%s');", string.JavascriptSafe(key)))
+    end
+end
+
+theater.RegisterService("yugen", SERVICE)

--- a/lua/cinema/theater/services/sv_yugen.lua
+++ b/lua/cinema/theater/services/sv_yugen.lua
@@ -1,0 +1,6 @@
+﻿-- This file is subject to copyright - contact swampservers@gmail.com for more information.
+sv_GetVideoInfo = sv_GetVideoInfo or {}
+
+sv_GetVideoInfo.yugen = function(self, key, ply, onSuccess, onFailure)
+    theater.GetVideoInfoClientside(self:GetClass(), key, ply, onSuccess, onFailure)
+end


### PR DESCRIPTION
Currently does not works, still needs some modifications here and there. However most of the base structure is around and i'd say in a good stage to be reviewed.

I could not test this by myself yet either, but assuming from other scripts and also on how the cinema code structure works everything should be at least syntax-correct, hopefully.

- [x] Initial embed fetching
- [x] Basic Title conversion
- [ ] Finish HLS resolution
- [x] Thumbnail fetching (can be grabbed from embed api)