### PR TITLE
Fix m3u URI parsing

### DIFF
--- a/lua/cinema/theater/services/sh_hls.lua
+++ b/lua/cinema/theater/services/sh_hls.lua
@@ -28,7 +28,7 @@ if CLIENT then
     end
 
     function SERVICE:LoadVideo(Video, panel)
-        panel:EnsureURL("https://swamp.sv/s/cinema/file.html")
+        panel:EnsureURL("https://swamp.sv/s/cinema/hls.html")
 
         panel:AddFunction("gmod", "loaded", function()
             self:SeekTo(CurTime() - Video:StartTime(), panel)

--- a/lua/cinema/theater/services/sv_hls.lua
+++ b/lua/cinema/theater/services/sv_hls.lua
@@ -34,7 +34,7 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
             if string.find(line, ".m3u8") then
                 local streamurl
             
-                if string.find(line, "http.://") then
+                if string.find(line, "https?://") then
                     streamurl = line
                 else -- relative path
                     local uri = string.match(line, 'URI="(.-)"')

--- a/lua/cinema/theater/services/sv_hls.lua
+++ b/lua/cinema/theater/services/sv_hls.lua
@@ -36,8 +36,9 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
 
                 --relative path
                 if not string.find(streamurl, "http.://") then
+                    local uri = string.match(streamurl, 'URI="(.-)"')
                     local path = string.Split(key, "/")
-                    path[#path] = streamurl
+                    path[#path] = uri
                     streamurl = table.concat(path, "/")
                 end
 

--- a/lua/cinema/theater/services/sv_hls.lua
+++ b/lua/cinema/theater/services/sv_hls.lua
@@ -30,13 +30,14 @@ sv_GetVideoInfo.hls = function(self, key, ply, onSuccess, onFailure)
     end
 
     self:Fetch(key, function(body)
-        for _, v in ipairs(string.Split(body, "\n")) do
-            if string.find(v, ".m3u8") then
-                local streamurl = v
-
-                --relative path
-                if not string.find(streamurl, "http.://") then
-                    local uri = string.match(streamurl, 'URI="(.-)"')
+        for _, line in ipairs(string.Split(body, "\n")) do
+            if string.find(line, ".m3u8") then
+                local streamurl
+            
+                if string.find(line, "http.://") then
+                    streamurl = line
+                else -- relative path
+                    local uri = string.match(line, 'URI="(.-)"')
                     local path = string.Split(key, "/")
                     path[#path] = uri
                     streamurl = table.concat(path, "/")


### PR DESCRIPTION
When we parse M3U, we check if a line contains `.m3u8`. If it does but does not contain `http/s` then we assume it's a partial URI. However we assumed that the URI would be the entire line, which fails in a lot of cases. M3U lets you set the URI with `URI=<URI>`

[examples](https://en.wikipedia.org/wiki/M3U)
```
NAME="English", TYPE=AUDIO, GROUP-ID="audio-stereo-64", LANGUAGE="en", DEFAULT=YES, AUTOSELECT=YES, URI="english.m3u8"
```

failing example from banned.video https://bytehighway.net/3d8d888117f88d252cab8fce4760adbe/manifest/video.m3u8