### PR TITLE
Add kick.com support

### DIFF
--- a/lua/cinema/theater/services/sh_kick.lua
+++ b/lua/cinema/theater/services/sh_kick.lua
@@ -1,0 +1,32 @@
+﻿-- This file is subject to copyright - contact swampservers@gmail.com for more information.
+local SERVICE = {}
+SERVICE.Name = "Kick"
+SERVICE.NeedsCodecs = true
+SERVICE.NeedsChromium = true
+
+function SERVICE:GetKey(url)
+    if not string.match(url.host or "", "kick.com") then return false end
+    local key = string.match(url.path, "^/([%w_]+)$")
+
+    if not key or string.len(key) < 1 then
+        key = false
+    end
+
+    return key
+end
+
+if CLIENT then
+    function SERVICE:LoadVideo(Video, panel)
+        panel:EnsureURL("https://player.kick.com/" .. Video:Key())
+    end
+
+    function SERVICE:SetVolume(vol, panel)
+        panel:QueueJavascript([[
+            document.querySelectorAll('audio, video').forEach(element => {
+                element.volume = ]] .. (vol * 0.01) .. [[;
+            });
+        ]])
+    end
+end
+
+theater.RegisterService('kick', SERVICE)

--- a/lua/cinema/theater/services/sh_kick.lua
+++ b/lua/cinema/theater/services/sh_kick.lua
@@ -17,7 +17,8 @@ end
 
 if CLIENT then
     function SERVICE:LoadVideo(Video, panel)
-        panel:EnsureURL("https://player.kick.com/" .. Video:Key())
+        panel:EnsureURL("https://player.kick.com/" .. Video:Key() .. "?autoplay=true&muted=false")
+        panel:QueueJavascript("document.querySelector('button[aria-label=\"Mute/Unmute\"]').click();")
     end
 
     function SERVICE:SetVolume(vol, panel)

--- a/lua/cinema/theater/services/sv_kick.lua
+++ b/lua/cinema/theater/services/sv_kick.lua
@@ -1,0 +1,21 @@
+﻿-- This file is subject to copyright - contact swampservers@gmail.com for more information.
+sv_GetVideoInfo = sv_GetVideoInfo or {}
+
+sv_GetVideoInfo.kick = function(self, key, ply, onSuccess, onFailure)
+    local onReceive = function(body, length, headers, code)
+        local t = util.JSONToTable(body)
+
+        if type(t) == "table" and t["livestream"]["session_title"] ~= nil and t["livestream"]["thumbnail"]["url"] ~= nil then
+            local info = {}
+            info.title = t["livestream"]["session_title"]
+            info.thumb = t["livestream"]["thumbnail"]["url"]
+            info.duration = 0
+
+            onSuccess(info)
+        else
+            onFailure('Theater_RequestFailed')
+        end
+    end
+
+    self:Fetch("https://kick.com/api/v2/channels/" .. key, onReceive, onFailure)
+end


### PR DESCRIPTION
I tested to the best of my ability but I dont have a way to run the sv code

tldr:
- Get the key from the url eg. `kitty` from `https://kick.com/kitty`
- Server hits kick API at `https://kick.com/api/v2/channels/$key` example: https://kick.com/api/v2/channels/kitty
- We get the thumbnail and stream title from that json
- Load the video with the kick player at `https://player.kick.com/$key`
- After we load the kick player, we need to press the unmute button on the page automatically because it always starts muted

SetVolume just finds all the video players on the page and sets the element volume for each