### PR TITLE
Revert to using file.html for .m3u8

### DIFF
--- a/lua/cinema/theater/services/sh_hls.lua
+++ b/lua/cinema/theater/services/sh_hls.lua
@@ -28,7 +28,7 @@ if CLIENT then
     end
 
     function SERVICE:LoadVideo(Video, panel)
-        panel:EnsureURL("https://swamp.sv/s/cinema/hls.html")
+        panel:EnsureURL("https://swamp.sv/s/cinema/file.html")
 
         panel:AddFunction("gmod", "loaded", function()
             self:SeekTo(CurTime() - Video:StartTime(), panel)


### PR DESCRIPTION
video.js seems much more reliable for seeking. There have been problems the last week or so where videos take forever to load or have problems when seeking. I confirmed this in the browser by just using hls.html directly. file.html didn't have these problems. So, we should revert.

I'll have to look into what's going on here. I would like to use hls.js because video.js doesn't work with all m3u8 playlist formats. Maybe it needs an update?